### PR TITLE
Add API explorer and fix base URL

### DIFF
--- a/frontend/document-manager/src/App.jsx
+++ b/frontend/document-manager/src/App.jsx
@@ -8,6 +8,7 @@ import BrainstormManager from './components/BrainstormManager';
 import ProjectWorkflow from './components/project/ProjectWorkflow';
 import TemplateSelector from './components/templates/TemplateSelector';
 import TestConnection from './components/TestConnection'; // ← Add this import
+import APIExplorer from './components/APIExplorer';
 import { useProject } from './hooks/useProject';
 
 function AppContent() {
@@ -47,7 +48,8 @@ function AppContent() {
           <Route path="/brainstorm" element={<BrainstormManager />} />
           <Route path="/project/:id" element={<ProjectWorkflow />} />
           <Route path="/project/:id/:step" element={<ProjectWorkflow />} />
-          <Route path="/test" element={<TestConnection />} /> {/* ← Add this route */}
+          <Route path="/explorer" element={<APIExplorer />} />
+          <Route path="/test" element={<TestConnection />} />
         </Routes>
       </main>
 

--- a/frontend/document-manager/src/api/APIClient.js
+++ b/frontend/document-manager/src/api/APIClient.js
@@ -7,10 +7,10 @@ class APIClient {
   }
 
   async request(endpoint, options = {}) {
-    // Always use /api prefix for consistency
-    const url = endpoint.startsWith('/api') 
-      ? `${this.baseURL}${endpoint}` 
-      : `${this.baseURL}/api${endpoint}`;
+    // Construct full URL without forcing an /api prefix
+    const url = endpoint.startsWith('http')
+      ? endpoint
+      : `${this.baseURL}${endpoint.startsWith('/') ? '' : '/'}${endpoint}`;
     
     const config = {
       headers: {

--- a/frontend/document-manager/src/components/APIExplorer.jsx
+++ b/frontend/document-manager/src/components/APIExplorer.jsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from 'react';
+import apiClient from '../api/client';
+
+const APIExplorer = () => {
+  const [spec, setSpec] = useState(null);
+  const [selected, setSelected] = useState(null);
+  const [payload, setPayload] = useState('{}');
+  const [response, setResponse] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchSpec = async () => {
+      try {
+        const res = await fetch(`${apiClient.baseURL}/openapi.json`);
+        const data = await res.json();
+        setSpec(data);
+      } catch (err) {
+        setError(err.message);
+      }
+    };
+    fetchSpec();
+  }, []);
+
+  const operations = React.useMemo(() => {
+    if (!spec) return [];
+    const ops = [];
+    for (const path in spec.paths) {
+      for (const method in spec.paths[path]) {
+        ops.push({ path, method: method.toUpperCase(), op: spec.paths[path][method] });
+      }
+    }
+    return ops;
+  }, [spec]);
+
+  const invoke = async () => {
+    if (!selected) return;
+    setError(null);
+    setResponse(null);
+
+    const options = { method: selected.method };
+    let bodyObj = null;
+    if (selected.method !== 'GET' && payload) {
+      try {
+        bodyObj = JSON.parse(payload);
+        options.body = JSON.stringify(bodyObj);
+        options.headers = { 'Content-Type': 'application/json' };
+      } catch (err) {
+        setError('Invalid JSON payload');
+        return;
+      }
+    }
+
+    try {
+      const res = await fetch(`${apiClient.baseURL}${selected.path}`, options);
+      const data = await res.json();
+      setResponse(data);
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="flex flex-col md:flex-row gap-6">
+      <div className="md:w-1/3">
+        <h2 className="text-xl font-semibold mb-4">API Endpoints</h2>
+        <ul className="space-y-2 max-h-[70vh] overflow-y-auto">
+          {operations.map((op, idx) => (
+            <li key={idx}>
+              <button
+                onClick={() => { setSelected(op); setPayload('{}'); setResponse(null); setError(null); }}
+                className={`w-full text-left px-3 py-2 rounded-md border ${selected === op ? 'bg-green-50 border-green-200' : 'bg-white border-gray-200 hover:bg-gray-50'}`}
+              >
+                <span className="font-mono text-xs mr-2">{op.method}</span>
+                <span className="font-mono text-sm">{op.path}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="md:flex-1">
+        {selected ? (
+          <div className="space-y-4">
+            <h2 className="text-xl font-semibold">{selected.method} {selected.path}</h2>
+            {selected.method !== 'GET' && (
+              <textarea
+                className="w-full border rounded p-2 font-mono text-sm"
+                rows={8}
+                value={payload}
+                onChange={(e) => setPayload(e.target.value)}
+              />
+            )}
+            <button
+              onClick={invoke}
+              className="px-4 py-2 bg-green-600 text-white rounded-md"
+            >Send</button>
+            {error && <pre className="text-red-600 whitespace-pre-wrap">{error}</pre>}
+            {response && (
+              <pre className="bg-gray-100 p-2 rounded text-sm overflow-x-auto whitespace-pre-wrap">
+{JSON.stringify(response, null, 2)}
+</pre>
+            )}
+          </div>
+        ) : (
+          <p className="text-gray-500">Select an endpoint to begin.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default APIExplorer;

--- a/frontend/document-manager/src/components/layout/Header.jsx
+++ b/frontend/document-manager/src/components/layout/Header.jsx
@@ -9,7 +9,8 @@ const Header = ({ onNewProject }) => {
     { name: 'Documents', path: '/documents', icon: '📄' },
     { name: 'Tables', path: '/tables', icon: '📊' },
     { name: 'Brainstorm', path: '/brainstorm', icon: '🧠' },
-    { name: 'Test API', path: '/test', icon: '🔧' } // ← Add this
+    { name: 'Explore API', path: '/explorer', icon: '📚' },
+    { name: 'Test API', path: '/test', icon: '🔧' }
   ];
 
   const isActive = (path) => {


### PR DESCRIPTION
## Summary
- fix APIClient to stop forcing `/api` prefix
- add a simple API explorer page for hitting any backend endpoint
- wire new explorer route and navigation link in header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852ebaf09dc8329bed093f3e1363d3b